### PR TITLE
Adding hostheader to ngrok

### DIFF
--- a/tutorial/03_ngrok.md
+++ b/tutorial/03_ngrok.md
@@ -7,7 +7,7 @@ Before you continue you should have [ngrok](https://ngrok.com) installed on your
 Run ngrok by executing the following from the command line:
 
 ```shell
-ngrok http 5000 -hostheader="localhost:5000"
+ngrok http 5000 -host-header="localhost:5000"
 ```
 
 This will start ngrok and will tunnel requests from an external ngrok url to your development machine on port 5000.

--- a/tutorial/03_ngrok.md
+++ b/tutorial/03_ngrok.md
@@ -7,7 +7,7 @@ Before you continue you should have [ngrok](https://ngrok.com) installed on your
 Run ngrok by executing the following from the command line:
 
 ```shell
-ngrok http 5000
+ngrok http 5000 -hostheader="localhost:5000"
 ```
 
 This will start ngrok and will tunnel requests from an external ngrok url to your development machine on port 5000.


### PR DESCRIPTION
For me to make it work on a Windows 10 machine, I needed to add -hostheader="localhost:5000" to the ngrok instruction. Updating the tutorial to help others struggling with the same issue.